### PR TITLE
Fix: unable to resolve dependency tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,5 @@
     "url": "git+https://github.com/ganeshrvel/npm-electron-is-packaged.git"
   },
   "homepage": "https://github.com/ganeshrvel/npm-electron-is-packaged",
-  "peerDependencies": {
-    "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0"
-  },
   "dependencies": {}
 }


### PR DESCRIPTION
```
While resolving: TiddlyGit@0.4.0
npm ERR! Found: eslint@7.29.0
npm ERR! node_modules/eslint
npm ERR!   dev eslint@"7.29.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer eslint@"^3.0.0 || ^4.0.0 || ^5.0.0" from electron-is-packaged@1.0.2
npm ERR! node_modules/electron-is-packaged
npm ERR!   electron-is-packaged@"1.0.2" from the root project
```